### PR TITLE
fix mermaid diagram and TOC

### DIFF
--- a/_docs/mldn-data-flow.md
+++ b/_docs/mldn-data-flow.md
@@ -36,8 +36,8 @@ B[("Raw Data
 Access Point
 (eg. RA ERDDAP)")]
 
-C{{"Darwin Core
-Alignment"}}
+C("Darwin Core
+Alignment")
 
 D[(NCEI)]
 
@@ -81,7 +81,7 @@ ERDDAP provides, a data manager can develop a reproducible workflow for aligning
 there is long-term stewardship of these data, as well as meeting our PARR requirements. The sections below provide more
 context as well as tips and tricks for each of the elements in the diagram above.
 
-### For MBON Projects
+## For MBON Projects
 Datasets should be registered in the [MBON dataset registration form](https://docs.google.com/forms/d/e/1FAIpQLSfguACbLmcLiFxHKsR5W5Mv9nEfd0E8oX2rY78gdwAYTrq_zA/viewform?usp=sf_link). This will ensure that we (the IOOS Marine Life DMAC team) are aware of the dataset and can track its progress through the data management and sharing workflows. 
 
 ## RA ERDDAP


### PR DESCRIPTION
Mermaid diagram syntax was broken because of the Jekyll rendering to html process. This adjusts the shape of the problematic node and fixes the webpage. See https://github.com/ioos/mbon-docs/issues/58#issuecomment-2343676525 for more details.

The TOC was broken because of the header of the "For MBON Projects" section. This needs to start as a second level header (`##`), not third (`###`). These changes fix the TOC.  

Closes #99 