### PR TITLE
Update associated party metadata-eml.md

### DIFF
--- a/_docs/metadata-eml.md
+++ b/_docs/metadata-eml.md
@@ -43,7 +43,7 @@ Scientific Name, Common Name, Taxon Rank for all species or at higher level if a
 
 **Associated Party (include First Name, Last Name, Position, Organization, Email, can link to ORCID):** <br/>
 **Associated Party Role (pick one per person from table below):** <br/>
-_`Role` information is also available at <https://ipt.gbif.org/manual/en/ipt/latest/manage-resources#contacts>._
+_`Role` information is also available at <https://rs.gbif.org/vocabulary/gbif/agent_role.xml>._
 
 | **Role**              | **Description**                                                                                                                                                                                           
 |:----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Potentially not a required change but the IPT manual points to a controlled vocabulary for the associated party roles. The link that is currently on the website does get you to the role descriptions (with some scrolling - it's not a direct link to that spot in the manual) but it might be nice to point directly to the vocabulary instead.